### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sentry_release.yml
+++ b/.github/workflows/sentry_release.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'package.json'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Headpat-Community/headpat-web/security/code-scanning/4](https://github.com/Headpat-Community/headpat-web/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow only reads the repository's contents (e.g., `package.json`) and does not perform any write operations.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. This ensures that the `GITHUB_TOKEN` permissions are limited for the entire workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
